### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.12 AS builder
+WORKDIR /go/src/github.com/justmiles/ssm-parameter-store/
+RUN adduser --system tooluser
+COPY . /go/src/github.com/justmiles/ssm-parameter-store/
+RUN go get -v
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /bin/ssm-parameter-store
+
+FROM scratch
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /bin/ssm-parameter-store /bin/ssm-parameter-store
+USER tooluser
+ENTRYPOINT ["/bin/ssm-parameter-store"]


### PR DESCRIPTION
A lot of modern continuous integration workflows are Docker-first.
This Dockerfile builds a container housing ssm-parameter-store for
use in environments where it is easier to run a container than to
download and install a binary package from GitHub.